### PR TITLE
Fix for KYLIN-1070

### DIFF
--- a/metadata/src/main/java/org/apache/kylin/metadata/model/DataModelDesc.java
+++ b/metadata/src/main/java/org/apache/kylin/metadata/model/DataModelDesc.java
@@ -150,6 +150,7 @@ public class DataModelDesc extends RootPersistentEntity {
     }
 
     public void init(Map<String, TableDesc> tables) {
+        setFactTable(getFactTable());
         initJoinColumns(tables);
         initPartitionDesc(tables);
     }


### PR DESCRIPTION
fact table is getting saves as it is without upper case